### PR TITLE
#6 Pass config into correct Lighthouse parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,17 @@ Search for **lighthouse.pageSummary.** there you will have all the metrics that 
 The look at the docs on how you can send them: [https://www.sitespeed.io/documentation/sitespeed.io/metrics/#add-a-metric](https://www.sitespeed.io/documentation/sitespeed.io/metrics/#add-a-metric).
 
 ## Configuration
-You can pass config to Lighthouse using the `--lighthouse` CLI flag. Since this plugin using the Lighthouse node module and not the CLI, some options in the CLI API are not available. You can find a list of supported flags by checking out the [SharedFlagsSetting](https://github.com/GoogleChrome/lighthouse/blob/41bc409deddb44dd607d2606b7e57e1d239641a7/types/externs.d.ts) interface in the Lighthouse repository.
+You can pass config to Lighthouse using the `--lighthouse` CLI flag. Since this plugin using the Lighthouse node module and not the CLI, some options from the CLI API are not available. You can find a list of supported flags by checking out the [SharedFlagsSetting](https://github.com/GoogleChrome/lighthouse/blob/41bc409deddb44dd607d2606b7e57e1d239641a7/types/externs.d.ts) interface in the Lighthouse repository.
 
-For example, to change the device type from 'mobile' to 'desktop' mode, you can use:
-`--lighthouse.extends lighthouse:default --lighthouse.settings.emulatedFormFactor desktop`.
+You can extend the Lighthouse presets by adding the `extends` property. By default, `lighthouse:default` is asssumed, so it can be omited. There are two options available:
 
-Please note that you will need to extend a lighthouse base configuration in order to pass custom settings.
+[lighthouse:default](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/config/default-config.js)\
+[lighthouse:full](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/config/full-config.js)
+
+**Example:** To change the device type from 'mobile' to 'desktop' mode, you could use:\
+`--lighthouse.extends lighthouse:default --lighthouse.settings.emulatedFormFactor desktop`
+
+To add multiple settings, repeat `--lighthouse.settings.*`.
 
 For more details, check out the [Lighthouse Configuration](https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md) page.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,14 @@ Search for **lighthouse.pageSummary.** there you will have all the metrics that 
 The look at the docs on how you can send them: [https://www.sitespeed.io/documentation/sitespeed.io/metrics/#add-a-metric](https://www.sitespeed.io/documentation/sitespeed.io/metrics/#add-a-metric).
 
 ## Configuration
-Everything that you pass on with --lighthouse.* will be passed to Lighthouse.
+You can pass config to Lighthouse using the `--lighthouse` CLI flag. Since this plugin using the Lighthouse node module and not the CLI, some options in the CLI API are not available. You can find a list of supported flags by checking out the [SharedFlagsSetting](https://github.com/GoogleChrome/lighthouse/blob/41bc409deddb44dd607d2606b7e57e1d239641a7/types/externs.d.ts) interface in the Lighthouse repository.
+
+For example, to change the device type from 'mobile' to 'desktop' mode, you can use:
+`--lighthouse.extends lighthouse:default --lighthouse.settings.emulatedFormFactor desktop`.
+
+Please note that you will need to extend a lighthouse base configuration in order to pass custom settings.
+
+For more details, check out the [Lighthouse Configuration](https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md) page.
 
 ## sitespeed.io version
 You need sitespeed.io 7.5 or later to run the plugin.

--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ async function launchChromeAndRunLighthouse(url, config) {
   return chromeLauncher
     .launch({ chromeFlags: defaultChromeSettings.chromeFlags })
     .then(chrome => {
+      if (config && !config.extends) {
+        config.extends = 'lighthouse:default';
+      }
       return lighthouse(url, { port: chrome.port }, config).then(results => {
         return chrome.kill().then(() => results.lhr);
       });

--- a/index.js
+++ b/index.js
@@ -17,12 +17,11 @@ const defaultChromeSettings = {
   chromeFlags: ['--no-sandbox', '--headless', '--disable-gpu']
 };
 
-async function launchChromeAndRunLighthouse(url, opts) {
+async function launchChromeAndRunLighthouse(url, config) {
   return chromeLauncher
     .launch({ chromeFlags: defaultChromeSettings.chromeFlags })
     .then(chrome => {
-      opts.port = chrome.port;
-      return lighthouse(url, opts).then(results => {
+      return lighthouse(url, { port: chrome.port }, config).then(results => {
         return chrome.kill().then(() => results.lhr);
       });
     });
@@ -40,7 +39,7 @@ module.exports = {
       'utf8'
     );
 
-    this.lightHouseOptions = options.lighthouse || {};
+    this.lightHouseOptions = options.lighthouse;
     this.usingBrowsertime = false;
     this.summaries = 0;
     this.urls = [];


### PR DESCRIPTION
The Lighthouse plugin was passing the config into the wrong parameter of the API. The first parameter is the URL, the second is for flags, such as the Chrome port, the third if config options for Lighthouse audits.

This example will allow you to set the device type:
`--lighthouse.extends lighthouse:default --lighthouse.settings.emulatedFormFactor desktop`

For a list of config options available in the Node library, check out [SharedFlagSettings](https://github.com/GoogleChrome/lighthouse/blob/41bc409deddb44dd607d2606b7e57e1d239641a7/types/externs.d.ts#L91).

See https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md for more details. 
