### PR TITLE
Added Lighthouse default reports generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ If you want to run Lighthouse with your other sitespeed.io test, follow the inst
 
 The Lighthouse tests will run after Browsertime finished and run Chrome headless.
 
+## Lighthouse reports
+By default, it will generate `lighthouse` report json-files in `/pages/YOURPAGE/data`.
+
+This examples will allow you to set the Lighthouse report type (output type):
+
+`--lighthouse.extends lighthouse:default --lighthouse.settings.output html` for html-reports,
+`--lighthouse.extends lighthouse:default --lighthouse.settings.output csv` for csv-reports.
+
 ## Data to Graphite/InfluxDB
 The plugin will automatically send the performance, pwa, best practice, accessibility and SEO score to Graphite/InfluxDB. 
 

--- a/index.js
+++ b/index.js
@@ -174,7 +174,6 @@ module.exports = {
               this.lightHouseOptions,
               this.lighthouseFlags
             );
-            log.info('Got Lighthouse metrics');
             log.verbose('Result from Lightouse:%:2j', result.lhr);
             queue.postMessage(
               make('lighthouse.pageSummary', result.lhr, {
@@ -210,7 +209,13 @@ module.exports = {
       case 'lighthouse.report': {
         return this.storageManager.writeDataForUrl(
           message.data,
-          'lighthouse',
+          `lighthouse.${
+            this.lightHouseOptions &&
+            this.lightHouseOptions.settings &&
+            this.lightHouseOptions.settings.output
+              ? this.lightHouseOptions.settings.output
+              : 'json'
+          }`,
           message.url
         );
       }

--- a/lighthouse.pug
+++ b/lighthouse.pug
@@ -2,6 +2,8 @@
 
 a
 h2 Lighthouse (version #{lh.lighthouseVersion})
+p Full Lighthouse report is available 
+  a(href=`./data/lighthouse.${(options.lighthouse && options.lighthouse.settings && options.lighthouse.settings.output) ? options.lighthouse.settings.output : "json"}`) here
 
 h3  Score 
 table


### PR DESCRIPTION
Added default Lighthouse reports generation for the Lighthouse plugin. 
By default, it will generate a `lighthouse` json-file in `/pages/YOURPAGE/data`.

This examples will allow you to set the Lighthouse report type (output type):
`--lighthouse.extends lighthouse:default --lighthouse.settings.output html` for html-report,
`--lighthouse.extends lighthouse:default --lighthouse.settings.output csv` for csv-report.