### PR TITLE
Add preScript argument for running Puppeteer script before audit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
 script:
   - npm run lint
   - sitespeed.io --plugins.add . https://www.sitespeed.io/ -n 1 --headless
+  - sitespeed.io --plugins.add . https://www.sitespeed.io/ -n 1 --headless --lighthouse.preScript ./test/preScriptTest.js
 notifications:
   slack:
     secure: CDiXaDmWzsA2IpKZiST744uZooaoTuJ+qTMWElSWsHIp6cA/mbOLcZGsmhemmKaYvKl7ASF8doJrCaBinmy59Unzs0Er/Kfp1gwlQ4wpbOk3Bj072bgM3r8ipIunnEa0S6ynGK6n2OtUZOlnmUsP1dha9ndRVsT+vK4W9xqzsl0grRXcvv+56vkzvcPGq7rATMnbIpT4DvbzgX0NoAyZZMz6/R1CPnGVirp/7dHB6+OYkt6wooM0yCJS32G1JsjoZMwHSqs697pVOsOziO6LZ9NlBRp5Fv0SsIFQAroX6zqOkWjtjR8sPs8MDqw8K2pM7Wi4NKgV1qUTqi1a9ScfgRZ2cg9o2hKsPHBSpYq1v4ijlNm7O4gAs0t0XupJtrUS9gi1cAnHKT0/JJDLXRZOmAYIeSH76WnefAEpcXGKXKWqOQVlG4/cPbD9Xi3WswWVUoxrFCWM+ORGdfM/qMbUtBWfD1HCM13Sqv/DDX5F2gFGQZda1WjWZQ11HEnZWFhGvT7kDYbPc816XMP26gpq3xxsi9vtfmo09RvFRk2mTwlXAK8ppS40GeAlNOolxWjPGrWZBzwIBVUmRiyKZf4KgIkBD3z9woDQnoFr+FWwe1Yi0uqqhov1iI8iu/xhjdEP8PDyfy1FuoF4mlE0xqBAFqGx55SWFKxlMaBixRqoYf0=

--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 const fs = require('fs');
 const path = require('path');
-const lighthouse = require('lighthouse');
-const chromeLauncher = require('chrome-launcher');
+const omit = require('object.omit');
+const runAudit = require('./runAudit');
 
 const DEFAULT_SUMMARY_METRICS = [
   'categories.seo.score',
@@ -12,39 +12,6 @@ const DEFAULT_SUMMARY_METRICS = [
   'categories.accessibility.score',
   'categories.best-practices.score'
 ];
-
-const defaultChromeSettings = {
-  chromeFlags: [
-    '--no-sandbox',
-    '--headless',
-    '--disable-gpu',
-    '--ignore-certificate-errors'
-  ]
-};
-
-async function launchChromeAndRunLighthouse(url, config, flags) {
-  return chromeLauncher
-    .launch({ chromeFlags: defaultChromeSettings.chromeFlags })
-    .then(chrome => {
-      if (config && !config.extends) {
-        config.extends = 'lighthouse:default';
-      }
-      return lighthouse(
-        url,
-        Object.assign(
-          {},
-          {
-            port: chrome.port
-          },
-          flags
-        ),
-        config
-      ).then(results => {
-        const lhrAndReport = { lhr: results.lhr, report: results.report };
-        return chrome.kill().then(() => lhrAndReport);
-      });
-    });
-}
 
 module.exports = {
   name() {
@@ -58,9 +25,13 @@ module.exports = {
       'utf8'
     );
 
-    this.lightHouseOptions = options.lighthouse;
+    this.lightHouseConfig =
+      options.lighthouse && omit(options.lighthouse, 'preScript');
 
     this.lighthouseFlags = options.verbose > 0 ? { logLevel: 'verbose' } : {};
+
+    this.lighthousePreScript =
+      options.lighthouse && options.lighthouse.preScript;
 
     this.usingBrowsertime = false;
     this.summaries = 0;
@@ -95,11 +66,12 @@ module.exports = {
                 urlAndGroup.url
               );
               try {
-                const result = await launchChromeAndRunLighthouse(
-                  urlAndGroup.url,
-                  this.lightHouseOptions,
-                  this.lighthouseFlags
-                );
+                const result = await runAudit({
+                  url: urlAndGroup.url,
+                  lightHouseConfig: this.lightHouseConfig,
+                  lighthouseFlags: this.lighthouseFlags,
+                  lighthousePreScript: this.lighthousePreScript
+                });
                 log.info('Got Lighthouse metrics');
                 log.verbose('Result from Lightouse:%:2j', result.lhr);
                 queue.postMessage(
@@ -169,11 +141,12 @@ module.exports = {
           const group = message.group;
           log.info('Start collecting Lighthouse result for %s', url);
           try {
-            const result = await launchChromeAndRunLighthouse(
+            const result = await runAudit({
               url,
-              this.lightHouseOptions,
-              this.lighthouseFlags
-            );
+              lightHouseConfig: this.lightHouseConfig,
+              lighthouseFlags: this.lighthouseFlags,
+              lighthousePreScript: this.lighthousePreScript
+            });
             log.verbose('Result from Lightouse:%:2j', result.lhr);
             queue.postMessage(
               make('lighthouse.pageSummary', result.lhr, {
@@ -210,10 +183,10 @@ module.exports = {
         return this.storageManager.writeDataForUrl(
           message.data,
           `lighthouse.${
-            this.lightHouseOptions &&
-            this.lightHouseOptions.settings &&
-            this.lightHouseOptions.settings.output
-              ? this.lightHouseOptions.settings.output
+            this.lightHouseConfig &&
+            this.lightHouseConfig.settings &&
+            this.lightHouseConfig.settings.output
+              ? this.lightHouseConfig.settings.output
               : 'json'
           }`,
           message.url

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,14 @@
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
       "dev": true
     },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
     "ajv": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
@@ -189,6 +197,11 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "callsites": {
       "version": "3.0.0",
@@ -345,6 +358,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "configstore": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
@@ -380,6 +404,11 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
       "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
       "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -484,6 +513,19 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "es6-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -746,6 +788,17 @@
         "tmp": "^0.0.33"
       }
     },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      }
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -769,6 +822,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "requires": {
+        "pend": "~1.2.0"
+      }
     },
     "figures": {
       "version": "2.0.0",
@@ -918,6 +979,30 @@
       "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-0.8.0.tgz",
       "integrity": "sha1-oitBoMmx4tj6wb8baXxr1TLV9eQ="
     },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1046,6 +1131,14 @@
         }
       }
     },
+    "is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "requires": {
+        "is-plain-object": "^2.0.4"
+      }
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -1076,6 +1169,14 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
         "path-is-inside": "^1.0.1"
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "^3.0.1"
       }
     },
     "is-promise": {
@@ -1112,10 +1213,20 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "jpeg-js": {
       "version": "0.1.2",
@@ -1140,9 +1251,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1288,6 +1399,11 @@
       "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.2.0.tgz",
       "integrity": "sha1-U1w84cz2IjpQJf3cahw2UF9+fbE="
     },
+    "mime": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
+      "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg=="
+    },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
@@ -1353,6 +1469,14 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object.omit": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-3.0.0.tgz",
+      "integrity": "sha512-EO+BCv6LJfu+gBIF3ggLicFebFLN5zqzz/WWJlMFfkMyGth+oBkhxzDl0wx2W4GkLzuQs/FsSkXZb2IMWQqmBQ==",
+      "requires": {
+        "is-extendable": "^1.0.0"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -1451,6 +1575,11 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -1495,11 +1624,20 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+    },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -1575,6 +1713,44 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "puppeteer": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.14.0.tgz",
+      "integrity": "sha512-SayS2wUX/8LF8Yo2Rkpc5nkAu4Jg3qu+OLTDSOZtisVQMB2Z5vjlY2TdPi/5CgZKiZroYIiyUN3sRX63El9iaw==",
+      "requires": {
+        "debug": "^4.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^6.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
     "raven": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
@@ -1603,6 +1779,20 @@
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "regenerator-runtime": {
@@ -1780,6 +1970,14 @@
         "strip-ansi": "^4.0.0"
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -1899,6 +2097,11 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -1950,6 +2153,11 @@
       "requires": {
         "prepend-http": "^1.0.1"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.3.2",
@@ -2138,6 +2346,14 @@
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "requires": {
         "camelcase": "^4.1.0"
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "requires": {
+        "fd-slicer": "~1.0.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "pug-lint": "2.5.0"
   },
   "dependencies": {
-    "lighthouse": "^4.2.0"
+    "lighthouse": "^4.2.0",
+    "object.omit": "^3.0.0",
+    "puppeteer": "^1.14.0"
   },
   "scripts": {
     "lint": "eslint . && npm run pug-lint",

--- a/runAudit.js
+++ b/runAudit.js
@@ -1,0 +1,71 @@
+const puppeteer = require('puppeteer');
+const lighthouse = require('lighthouse');
+
+const defaultChromeSettings = {
+  ignoreHTTPSErrors: true,
+  headless: true,
+  args: ['--no-sandbox', '--disable-gpu']
+};
+
+const launchBrowser = async () => puppeteer.launch(defaultChromeSettings);
+
+const closeBrowser = async browser => browser.close();
+
+const getPort = browser => {
+  const browserWSEndpoint = browser.wsEndpoint();
+  const { port } = require('url').parse(browserWSEndpoint);
+  return port;
+};
+
+const executePreScript = ({ browser, lighthousePreScript }) =>
+  require(lighthousePreScript)(browser);
+
+const runLighthouse = async ({
+  url,
+  port,
+  lightHouseConfig,
+  lighthouseFlags
+}) => {
+  if (lightHouseConfig && !lightHouseConfig.extends) {
+    lightHouseConfig.extends = 'lighthouse:default';
+  }
+
+  const results = await lighthouse(
+    url,
+    Object.assign(
+      {},
+      {
+        port
+      },
+      lighthouseFlags
+    ),
+    lightHouseConfig
+  );
+
+  const lhrAndReport = { lhr: results.lhr, report: results.report };
+  return lhrAndReport;
+};
+
+module.exports = async function runAudit({
+  url,
+  lightHouseConfig,
+  lighthouseFlags,
+  lighthousePreScript
+}) {
+  const browser = await launchBrowser();
+
+  if (lighthousePreScript) {
+    await executePreScript({ browser, lighthousePreScript });
+  }
+
+  const results = await runLighthouse({
+    url,
+    port: getPort(browser),
+    lightHouseConfig,
+    lighthouseFlags
+  });
+
+  await closeBrowser(browser);
+
+  return results;
+};

--- a/test/preScriptTest.js
+++ b/test/preScriptTest.js
@@ -1,0 +1,6 @@
+module.exports = async function preScript(browser) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1300, height: 700 });
+
+  await page.goto('https://www.sitespeed.io/');
+};


### PR DESCRIPTION
- Swap `chrome-launcher` for `puppeteer` so we can allow for browser automation
- Execute async Node script that is passed to `--lighthouse.preScript` option
- Node script is given the browser instance
- Pass browser port to Lighthouse to do audit after the script has executed

The Node script would look something like this:

```js
module.exports = async function preScript(browser) {
    const page = await browser.newPage();
    await page.goto('https://www.google.com/');
    // do login stuff here...
};
```
