### PR TITLE
Graceful publishing of stats

### DIFF
--- a/aggregator.js
+++ b/aggregator.js
@@ -10,30 +10,26 @@ class Aggregator {
     this.stats = {};
   }
 
+  _pushStats(path, value) {
+    if (!(value > 0)) {
+      this.log.info(`stat ${path} was empty, skipping`);
+      return;
+    }
+    this.statsHelpers.pushStats(this.stats, path, value);
+  }
+
   addToAggregate(result) {
     forEach(result.categories, category => {
-      this.statsHelpers.pushStats(
-        this.stats,
-        ['categories', category.id],
-        category.score
-      );
+      this._pushStats(['categories', category.id], category.score);
     });
 
     forEach(result.audits, audit => {
       switch (audit.scoreDisplayMode) {
         case 'numeric':
-          this.statsHelpers.pushStats(
-            this.stats,
-            ['audits', audit.id],
-            audit.numericValue
-          );
+          this._pushStats(['audits', audit.id], audit.numericValue);
           break;
         case 'binary':
-          this.statsHelpers.pushStats(
-            this.stats,
-            ['audits', audit.id],
-            audit.score
-          );
+          this._pushStats(['audits', audit.id], audit.score);
           break;
         default:
           break;


### PR DESCRIPTION
* Fixes #40 – more info about the underlying issue in #40 
* Gracefully publish stats for each iteration
* If some categories are empty, skip and continue to next iteration
* This especially happens with non-PWA websites
* On one hand, it may sound like a hard fail is good. But on the other hand, since we have multiple iterations, these cases always happen for one page or the other and it's annoying to have the whole sitespeed build fail just due to one iteration. We users are fine and we even expect one or two iterations to fail, since we have multiple iterations as a fallback
* Debated whether we should publish zero score, or skip and continue. If we publish zero score, it would skew the metrics towards zero, hence skipping that one stat and continuing to next iteration