### PR TITLE
This commit adds main audits to the default list of reported metrics …

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,14 @@ const DEFAULT_MULTI_RUN_SUMMARY_METRICS = [
   'categories.performance.*',
   'categories.pwa.*',
   'categories.accessibility.*',
-  'categories.best-practices.*'
+  'categories.best-practices.*',
+  'audits.first-contentful-paint.*',
+  'audits.first-meaningful-paint.*',
+  'audits.first-cpu-idle.*',
+  'audits.speed-index.*',
+  'audits.estimated-input-latency.*',
+  'audits.max-potential-fid.*',
+  'audits.interactive.*'
 ];
 
 const defaultConfig = {


### PR DESCRIPTION
…for multi run. Unfortunately, my skills in node js are limited and I can not fix the problem with the metrics in multi run in another way (In multi run in latest release available only default metrics and you can not choose any else). Please, push it to the sitespeed ASAP.