### PR TITLE
Enable test to be run manually

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,6 @@
 name: Run Lighthouse plugin on Linux
 on:
+  workflow_dispatch:
   push:
     branches:
     - main


### PR DESCRIPTION
We should enable our test suite to be run manually as we rely on sitespeed@latest (that will change over time).
Latest failed tests will success if run again as it used a different version of sitespeed.